### PR TITLE
Delete Key for Gmail v1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+__v1.1:__
+
+* Fixed bug where delete action would fire if the user was typing in a text field
+
 __v1.0:__
 
 * Initial release

--- a/extension/js/contentscript.js
+++ b/extension/js/contentscript.js
@@ -18,6 +18,10 @@ function deleteMail() {
     // Find out what element is currently in focus
     try {
         var focusedElement = document.activeElement;
+        if (focusedElement.getAttribute('contenteditable') || focusedElement.tagName == "INPUT") {
+            // Don't delete the email if the user is using an input element or an editable element (aka typing an email or doing a search)
+            return
+        }
     } catch (err) {
         console.log("Error finding focused element: " + err)
     }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
 "manifest_version": 2,
 	"name": "Delete Key for Gmail™",
-	"version": "1.0",
+	"version": "1.1",
 	"author": "Android Police",
 	"homepage_url": "https://github.com/android-police/delete-single-email-extension",
 	"description": "Delete a single email in Gmail™ with a customizable user shortcut (default is Shift + 5).",


### PR DESCRIPTION
* Fixed bug where delete action would fire if the user was typing in a text field